### PR TITLE
Return parsed response when only failing validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	golang.org/x/sys v0.0.0-20180928133829-e4b3c5e90611 // indirect
 	golang.org/x/text v0.0.0-20180911161511-905a57155faa
 )
+
+go 1.9


### PR DESCRIPTION
Hey again Aaron! Let me know your thoughts on this more flexible version of `ofxgo.ParseResponse`. It still returns an error if things are not parseable, but attempts to continue decoding if it's only hitting `Valid()`-ation errors. This way I can write institution-specific handling of validation errors and still use the response object.

I ran into this issue with Ally Bank where their severity in the transaction list is not uppercase like the OFX 102 spec requires. I've contacted them, but I don't expect they'll actually change anything since "it works for Quicken". 😉 