### PR TITLE
Added Accept http header as Citi now requires it

### DIFF
--- a/basic_client.go
+++ b/basic_client.go
@@ -75,6 +75,7 @@ func (c *BasicClient) RawRequest(URL string, r io.Reader) (*http.Response, error
 		return nil, err
 	}
 	request.Header.Set("Content-Type", "application/x-ofx")
+	request.Header.Add("Accept", "*/*, application/x-ofx")
 	if c.UserAgent != "" {
 		request.Header.Set("User-Agent", c.UserAgent)
 	}


### PR DESCRIPTION
Without this header set Citi returns http 403 for every request.

I spent far to long looking into why Citi started returning only 403s for me. I eventually found that the software pocketsense (https://pocketsense.blogspot.com/2021/08/dev-testing-continued.html) was having a similar issue and it was resolved by adding this http header to the requests. I confirmed it resolves the issue for me as well. 