### PR TITLE
Check for nil Currency fields in transactions

### DIFF
--- a/cmd/ofx/banktransactions.go
+++ b/cmd/ofx/banktransactions.go
@@ -77,7 +77,7 @@ func bankTransactions() {
 
 func printTransaction(defCurrency ofxgo.CurrSymbol, tran *ofxgo.Transaction) {
 	currency := defCurrency
-	if ok, _ := tran.Currency.Valid(); ok {
+	if tran.Currency != nil {
 		currency = tran.Currency.CurSym
 	}
 

--- a/cmd/ofx/cctransactions.go
+++ b/cmd/ofx/cctransactions.go
@@ -60,7 +60,7 @@ func ccTransactions() {
 		fmt.Println("Transactions:")
 		for _, tran := range stmt.BankTranList.Transactions {
 			currency := stmt.CurDef
-			if ok, _ := tran.Currency.Valid(); ok {
+			if tran.Currency != nil {
 				currency = tran.Currency.CurSym
 			}
 

--- a/common.go
+++ b/common.go
@@ -362,11 +362,7 @@ type Currency struct {
 }
 
 // Valid returns whether the Currency is valid according to the OFX spec
-func (c *Currency) Valid() (bool, error) {
-	if c == nil {
-		return false, errors.New("Currency is nil")
-	}
-
+func (c Currency) Valid() (bool, error) {
 	if c.CurRate.IsInt() && c.CurRate.Num().Int64() == 0 {
 		return false, errors.New("CurRate may not be zero")
 	} else if ok, err := c.CurSym.Valid(); !ok {


### PR DESCRIPTION
This requires changing function Valid() to use a pointer receiver. Nil
instances are considered invalid.

Fixes #44.