### PR TITLE
Add missing handling for `-dryrun` flag in command-line client

### DIFF
--- a/cmd/ofx/bankdownload.go
+++ b/cmd/ofx/bankdownload.go
@@ -64,6 +64,11 @@ func download() {
 
 	query.Bank = append(query.Bank, &statementRequest)
 
+	if dryrun {
+		printRequest(client, query)
+		return
+	}
+
 	response, err := client.RequestNoParse(query)
 	if err != nil {
 		fmt.Println("Error requesting account statement:", err)

--- a/cmd/ofx/banktransactions.go
+++ b/cmd/ofx/banktransactions.go
@@ -49,6 +49,11 @@ func bankTransactions() {
 
 	query.Bank = append(query.Bank, &statementRequest)
 
+	if dryrun {
+		printRequest(client, query)
+		return
+	}
+
 	response, err := client.Request(query)
 	if err != nil {
 		fmt.Println("Error requesting account statement:", err)

--- a/cmd/ofx/ccdownload.go
+++ b/cmd/ofx/ccdownload.go
@@ -51,6 +51,11 @@ func ccDownload() {
 	}
 	query.CreditCard = append(query.CreditCard, &statementRequest)
 
+	if dryrun {
+		printRequest(client, query)
+		return
+	}
+
 	response, err := client.RequestNoParse(query)
 
 	if err != nil {

--- a/cmd/ofx/cctransactions.go
+++ b/cmd/ofx/cctransactions.go
@@ -38,6 +38,11 @@ func ccTransactions() {
 	}
 	query.CreditCard = append(query.CreditCard, &statementRequest)
 
+	if dryrun {
+		printRequest(client, query)
+		return
+	}
+
 	response, err := client.Request(query)
 	if err != nil {
 		fmt.Println("Error requesting account statement:", err)

--- a/cmd/ofx/get_accounts.go
+++ b/cmd/ofx/get_accounts.go
@@ -35,6 +35,11 @@ func getAccounts() {
 	}
 	query.Signup = append(query.Signup, &acctInfo)
 
+	if dryrun {
+		printRequest(client, query)
+		return
+	}
+
 	response, err := client.Request(query)
 	if err != nil {
 		fmt.Println("Error requesting account information:", err)

--- a/cmd/ofx/invdownload.go
+++ b/cmd/ofx/invdownload.go
@@ -60,6 +60,11 @@ func invDownload() {
 	}
 	query.InvStmt = append(query.InvStmt, &statementRequest)
 
+	if dryrun {
+		printRequest(client, query)
+		return
+	}
+
 	response, err := client.RequestNoParse(query)
 
 	if err != nil {

--- a/cmd/ofx/invtransactions.go
+++ b/cmd/ofx/invtransactions.go
@@ -45,6 +45,11 @@ func invTransactions() {
 	}
 	query.InvStmt = append(query.InvStmt, &statementRequest)
 
+	if dryrun {
+		printRequest(client, query)
+		return
+	}
+
 	response, err := client.Request(query)
 	if err != nil {
 		os.Exit(1)


### PR DESCRIPTION
This flag was only handled for the `download-profile` command. Add the same handling for all other commands (except `detect-settings`).