### PR TITLE
Pass by value in `MarshalXML`.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -69,11 +69,11 @@ func (e *ofxVersion) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 	return e.FromString(value)
 }
 
-func (e *ofxVersion) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e ofxVersion) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(ofxVersions[*e-1], start)
+	enc.EncodeElement(ofxVersions[e-1], start)
 	return nil
 }
 
@@ -137,11 +137,11 @@ func (e *acctType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *acctType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e acctType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(acctTypes[*e-1], start)
+	enc.EncodeElement(acctTypes[e-1], start)
 	return nil
 }
 
@@ -218,11 +218,11 @@ func (e *trnType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *trnType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e trnType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(trnTypes[*e-1], start)
+	enc.EncodeElement(trnTypes[e-1], start)
 	return nil
 }
 
@@ -284,11 +284,11 @@ func (e *imageType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *imageType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e imageType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(imageTypes[*e-1], start)
+	enc.EncodeElement(imageTypes[e-1], start)
 	return nil
 }
 
@@ -350,11 +350,11 @@ func (e *imageRefType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 	return e.FromString(value)
 }
 
-func (e *imageRefType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e imageRefType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(imageRefTypes[*e-1], start)
+	enc.EncodeElement(imageRefTypes[e-1], start)
 	return nil
 }
 
@@ -416,11 +416,11 @@ func (e *checkSup) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *checkSup) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e checkSup) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(checkSups[*e-1], start)
+	enc.EncodeElement(checkSups[e-1], start)
 	return nil
 }
 
@@ -481,11 +481,11 @@ func (e *correctAction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 	return e.FromString(value)
 }
 
-func (e *correctAction) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e correctAction) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(correctActions[*e-1], start)
+	enc.EncodeElement(correctActions[e-1], start)
 	return nil
 }
 
@@ -547,11 +547,11 @@ func (e *balType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *balType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e balType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(balTypes[*e-1], start)
+	enc.EncodeElement(balTypes[e-1], start)
 	return nil
 }
 
@@ -617,11 +617,11 @@ func (e *inv401kSource) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 	return e.FromString(value)
 }
 
-func (e *inv401kSource) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e inv401kSource) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(inv401kSources[*e-1], start)
+	enc.EncodeElement(inv401kSources[e-1], start)
 	return nil
 }
 
@@ -684,11 +684,11 @@ func (e *subAcctType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 	return e.FromString(value)
 }
 
-func (e *subAcctType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e subAcctType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(subAcctTypes[*e-1], start)
+	enc.EncodeElement(subAcctTypes[e-1], start)
 	return nil
 }
 
@@ -749,11 +749,11 @@ func (e *buyType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *buyType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e buyType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(buyTypes[*e-1], start)
+	enc.EncodeElement(buyTypes[e-1], start)
 	return nil
 }
 
@@ -815,11 +815,11 @@ func (e *optAction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *optAction) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e optAction) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(optActions[*e-1], start)
+	enc.EncodeElement(optActions[e-1], start)
 	return nil
 }
 
@@ -880,11 +880,11 @@ func (e *tferAction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 	return e.FromString(value)
 }
 
-func (e *tferAction) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e tferAction) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(tferActions[*e-1], start)
+	enc.EncodeElement(tferActions[e-1], start)
 	return nil
 }
 
@@ -945,11 +945,11 @@ func (e *posType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *posType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e posType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(posTypes[*e-1], start)
+	enc.EncodeElement(posTypes[e-1], start)
 	return nil
 }
 
@@ -1010,11 +1010,11 @@ func (e *secured) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *secured) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e secured) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(secureds[*e-1], start)
+	enc.EncodeElement(secureds[e-1], start)
 	return nil
 }
 
@@ -1076,11 +1076,11 @@ func (e *duration) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *duration) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e duration) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(durations[*e-1], start)
+	enc.EncodeElement(durations[e-1], start)
 	return nil
 }
 
@@ -1142,11 +1142,11 @@ func (e *restriction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 	return e.FromString(value)
 }
 
-func (e *restriction) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e restriction) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(restrictions[*e-1], start)
+	enc.EncodeElement(restrictions[e-1], start)
 	return nil
 }
 
@@ -1207,11 +1207,11 @@ func (e *unitType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *unitType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e unitType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(unitTypes[*e-1], start)
+	enc.EncodeElement(unitTypes[e-1], start)
 	return nil
 }
 
@@ -1272,11 +1272,11 @@ func (e *optBuyType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 	return e.FromString(value)
 }
 
-func (e *optBuyType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e optBuyType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(optBuyTypes[*e-1], start)
+	enc.EncodeElement(optBuyTypes[e-1], start)
 	return nil
 }
 
@@ -1337,11 +1337,11 @@ func (e *sellType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *sellType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e sellType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(sellTypes[*e-1], start)
+	enc.EncodeElement(sellTypes[e-1], start)
 	return nil
 }
 
@@ -1410,11 +1410,11 @@ func (e *loanPmtFreq) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 	return e.FromString(value)
 }
 
-func (e *loanPmtFreq) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e loanPmtFreq) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(loanPmtFreqs[*e-1], start)
+	enc.EncodeElement(loanPmtFreqs[e-1], start)
 	return nil
 }
 
@@ -1478,11 +1478,11 @@ func (e *incomeType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 	return e.FromString(value)
 }
 
-func (e *incomeType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e incomeType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(incomeTypes[*e-1], start)
+	enc.EncodeElement(incomeTypes[e-1], start)
 	return nil
 }
 
@@ -1544,11 +1544,11 @@ func (e *sellReason) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 	return e.FromString(value)
 }
 
-func (e *sellReason) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e sellReason) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(sellReasons[*e-1], start)
+	enc.EncodeElement(sellReasons[e-1], start)
 	return nil
 }
 
@@ -1609,11 +1609,11 @@ func (e *optSellType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 	return e.FromString(value)
 }
 
-func (e *optSellType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e optSellType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(optSellTypes[*e-1], start)
+	enc.EncodeElement(optSellTypes[e-1], start)
 	return nil
 }
 
@@ -1676,11 +1676,11 @@ func (e *relType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *relType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e relType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(relTypes[*e-1], start)
+	enc.EncodeElement(relTypes[e-1], start)
 	return nil
 }
 
@@ -1743,11 +1743,11 @@ func (e *charType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *charType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e charType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(charTypes[*e-1], start)
+	enc.EncodeElement(charTypes[e-1], start)
 	return nil
 }
 
@@ -1808,11 +1808,11 @@ func (e *syncMode) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *syncMode) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e syncMode) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(syncModes[*e-1], start)
+	enc.EncodeElement(syncModes[e-1], start)
 	return nil
 }
 
@@ -1873,11 +1873,11 @@ func (e *ofxSec) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *ofxSec) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e ofxSec) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(ofxSecs[*e-1], start)
+	enc.EncodeElement(ofxSecs[e-1], start)
 	return nil
 }
 
@@ -1938,11 +1938,11 @@ func (e *debtType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *debtType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e debtType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(debtTypes[*e-1], start)
+	enc.EncodeElement(debtTypes[e-1], start)
 	return nil
 }
 
@@ -2005,11 +2005,11 @@ func (e *debtClass) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *debtClass) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e debtClass) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(debtClasss[*e-1], start)
+	enc.EncodeElement(debtClasss[e-1], start)
 	return nil
 }
 
@@ -2073,11 +2073,11 @@ func (e *couponFreq) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 	return e.FromString(value)
 }
 
-func (e *couponFreq) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e couponFreq) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(couponFreqs[*e-1], start)
+	enc.EncodeElement(couponFreqs[e-1], start)
 	return nil
 }
 
@@ -2140,11 +2140,11 @@ func (e *callType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *callType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e callType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(callTypes[*e-1], start)
+	enc.EncodeElement(callTypes[e-1], start)
 	return nil
 }
 
@@ -2210,11 +2210,11 @@ func (e *assetClass) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 	return e.FromString(value)
 }
 
-func (e *assetClass) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e assetClass) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(assetClasss[*e-1], start)
+	enc.EncodeElement(assetClasss[e-1], start)
 	return nil
 }
 
@@ -2276,11 +2276,11 @@ func (e *mfType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *mfType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e mfType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(mfTypes[*e-1], start)
+	enc.EncodeElement(mfTypes[e-1], start)
 	return nil
 }
 
@@ -2341,11 +2341,11 @@ func (e *optType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *optType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e optType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(optTypes[*e-1], start)
+	enc.EncodeElement(optTypes[e-1], start)
 	return nil
 }
 
@@ -2408,11 +2408,11 @@ func (e *stockType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *stockType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e stockType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(stockTypes[*e-1], start)
+	enc.EncodeElement(stockTypes[e-1], start)
 	return nil
 }
 
@@ -2476,11 +2476,11 @@ func (e *holderType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 	return e.FromString(value)
 }
 
-func (e *holderType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e holderType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(holderTypes[*e-1], start)
+	enc.EncodeElement(holderTypes[e-1], start)
 	return nil
 }
 
@@ -2543,11 +2543,11 @@ func (e *acctClassification) UnmarshalXML(d *xml.Decoder, start xml.StartElement
 	return e.FromString(value)
 }
 
-func (e *acctClassification) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e acctClassification) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(acctClassifications[*e-1], start)
+	enc.EncodeElement(acctClassifications[e-1], start)
 	return nil
 }
 
@@ -2609,11 +2609,11 @@ func (e *svcStatus) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return e.FromString(value)
 }
 
-func (e *svcStatus) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e svcStatus) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(svcStatuss[*e-1], start)
+	enc.EncodeElement(svcStatuss[e-1], start)
 	return nil
 }
 
@@ -2683,11 +2683,11 @@ func (e *usProductType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 	return e.FromString(value)
 }
 
-func (e *usProductType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+func (e usProductType) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if !e.Valid() {
 		return nil
 	}
-	enc.EncodeElement(usProductTypes[*e-1], start)
+	enc.EncodeElement(usProductTypes[e-1], start)
 	return nil
 }
 

--- a/constants_test.go
+++ b/constants_test.go
@@ -56,6 +56,18 @@ func TestOfxVersion(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E ofxVersion
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct OfxVersion): %s\n", err)
+	}
+	if string(b) != "<SC><E>220</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>220</E></SC>", string(b))
+	}
 }
 
 func TestAcctType(t *testing.T) {
@@ -100,6 +112,18 @@ func TestAcctType(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E acctType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct AcctType): %s\n", err)
+	}
+	if string(b) != "<SC><E>CD</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>CD</E></SC>", string(b))
 	}
 }
 
@@ -146,6 +170,18 @@ func TestTrnType(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E trnType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct TrnType): %s\n", err)
+	}
+	if string(b) != "<SC><E>OTHER</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>OTHER</E></SC>", string(b))
+	}
 }
 
 func TestImageType(t *testing.T) {
@@ -190,6 +226,18 @@ func TestImageType(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E imageType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct ImageType): %s\n", err)
+	}
+	if string(b) != "<SC><E>TAX</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>TAX</E></SC>", string(b))
 	}
 }
 
@@ -236,6 +284,18 @@ func TestImageRefType(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E imageRefType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct ImageRefType): %s\n", err)
+	}
+	if string(b) != "<SC><E>FORMURL</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>FORMURL</E></SC>", string(b))
+	}
 }
 
 func TestCheckSup(t *testing.T) {
@@ -280,6 +340,18 @@ func TestCheckSup(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E checkSup
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct CheckSup): %s\n", err)
+	}
+	if string(b) != "<SC><E>FRONTANDBACK</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>FRONTANDBACK</E></SC>", string(b))
 	}
 }
 
@@ -326,6 +398,18 @@ func TestCorrectAction(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E correctAction
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct CorrectAction): %s\n", err)
+	}
+	if string(b) != "<SC><E>REPLACE</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>REPLACE</E></SC>", string(b))
+	}
 }
 
 func TestBalType(t *testing.T) {
@@ -370,6 +454,18 @@ func TestBalType(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E balType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct BalType): %s\n", err)
+	}
+	if string(b) != "<SC><E>NUMBER</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>NUMBER</E></SC>", string(b))
 	}
 }
 
@@ -416,6 +512,18 @@ func TestInv401kSource(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E inv401kSource
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct Inv401kSource): %s\n", err)
+	}
+	if string(b) != "<SC><E>OTHERNONVEST</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>OTHERNONVEST</E></SC>", string(b))
+	}
 }
 
 func TestSubAcctType(t *testing.T) {
@@ -460,6 +568,18 @@ func TestSubAcctType(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E subAcctType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct SubAcctType): %s\n", err)
+	}
+	if string(b) != "<SC><E>OTHER</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>OTHER</E></SC>", string(b))
 	}
 }
 
@@ -506,6 +626,18 @@ func TestBuyType(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E buyType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct BuyType): %s\n", err)
+	}
+	if string(b) != "<SC><E>BUYTOCOVER</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>BUYTOCOVER</E></SC>", string(b))
+	}
 }
 
 func TestOptAction(t *testing.T) {
@@ -550,6 +682,18 @@ func TestOptAction(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E optAction
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct OptAction): %s\n", err)
+	}
+	if string(b) != "<SC><E>EXPIRE</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>EXPIRE</E></SC>", string(b))
 	}
 }
 
@@ -596,6 +740,18 @@ func TestTferAction(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E tferAction
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct TferAction): %s\n", err)
+	}
+	if string(b) != "<SC><E>OUT</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>OUT</E></SC>", string(b))
+	}
 }
 
 func TestPosType(t *testing.T) {
@@ -640,6 +796,18 @@ func TestPosType(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E posType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct PosType): %s\n", err)
+	}
+	if string(b) != "<SC><E>SHORT</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>SHORT</E></SC>", string(b))
 	}
 }
 
@@ -686,6 +854,18 @@ func TestSecured(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E secured
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct Secured): %s\n", err)
+	}
+	if string(b) != "<SC><E>COVERED</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>COVERED</E></SC>", string(b))
+	}
 }
 
 func TestDuration(t *testing.T) {
@@ -730,6 +910,18 @@ func TestDuration(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E duration
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct Duration): %s\n", err)
+	}
+	if string(b) != "<SC><E>IMMEDIATE</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>IMMEDIATE</E></SC>", string(b))
 	}
 }
 
@@ -776,6 +968,18 @@ func TestRestriction(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E restriction
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct Restriction): %s\n", err)
+	}
+	if string(b) != "<SC><E>NONE</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>NONE</E></SC>", string(b))
+	}
 }
 
 func TestUnitType(t *testing.T) {
@@ -820,6 +1024,18 @@ func TestUnitType(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E unitType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct UnitType): %s\n", err)
+	}
+	if string(b) != "<SC><E>CURRENCY</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>CURRENCY</E></SC>", string(b))
 	}
 }
 
@@ -866,6 +1082,18 @@ func TestOptBuyType(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E optBuyType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct OptBuyType): %s\n", err)
+	}
+	if string(b) != "<SC><E>BUYTOCLOSE</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>BUYTOCLOSE</E></SC>", string(b))
+	}
 }
 
 func TestSellType(t *testing.T) {
@@ -910,6 +1138,18 @@ func TestSellType(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E sellType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct SellType): %s\n", err)
+	}
+	if string(b) != "<SC><E>SELLSHORT</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>SELLSHORT</E></SC>", string(b))
 	}
 }
 
@@ -956,6 +1196,18 @@ func TestLoanPmtFreq(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E loanPmtFreq
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct LoanPmtFreq): %s\n", err)
+	}
+	if string(b) != "<SC><E>OTHER</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>OTHER</E></SC>", string(b))
+	}
 }
 
 func TestIncomeType(t *testing.T) {
@@ -1000,6 +1252,18 @@ func TestIncomeType(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E incomeType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct IncomeType): %s\n", err)
+	}
+	if string(b) != "<SC><E>MISC</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>MISC</E></SC>", string(b))
 	}
 }
 
@@ -1046,6 +1310,18 @@ func TestSellReason(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E sellReason
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct SellReason): %s\n", err)
+	}
+	if string(b) != "<SC><E>MATURITY</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>MATURITY</E></SC>", string(b))
+	}
 }
 
 func TestOptSellType(t *testing.T) {
@@ -1090,6 +1366,18 @@ func TestOptSellType(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E optSellType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct OptSellType): %s\n", err)
+	}
+	if string(b) != "<SC><E>SELLTOOPEN</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>SELLTOOPEN</E></SC>", string(b))
 	}
 }
 
@@ -1136,6 +1424,18 @@ func TestRelType(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E relType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct RelType): %s\n", err)
+	}
+	if string(b) != "<SC><E>OTHER</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>OTHER</E></SC>", string(b))
+	}
 }
 
 func TestCharType(t *testing.T) {
@@ -1180,6 +1480,18 @@ func TestCharType(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E charType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct CharType): %s\n", err)
+	}
+	if string(b) != "<SC><E>ALPHAANDNUMERIC</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>ALPHAANDNUMERIC</E></SC>", string(b))
 	}
 }
 
@@ -1226,6 +1538,18 @@ func TestSyncMode(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E syncMode
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct SyncMode): %s\n", err)
+	}
+	if string(b) != "<SC><E>LITE</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>LITE</E></SC>", string(b))
+	}
 }
 
 func TestOfxSec(t *testing.T) {
@@ -1270,6 +1594,18 @@ func TestOfxSec(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E ofxSec
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct OfxSec): %s\n", err)
+	}
+	if string(b) != "<SC><E>TYPE 1</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>TYPE 1</E></SC>", string(b))
 	}
 }
 
@@ -1316,6 +1652,18 @@ func TestDebtType(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E debtType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct DebtType): %s\n", err)
+	}
+	if string(b) != "<SC><E>ZERO</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>ZERO</E></SC>", string(b))
+	}
 }
 
 func TestDebtClass(t *testing.T) {
@@ -1360,6 +1708,18 @@ func TestDebtClass(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E debtClass
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct DebtClass): %s\n", err)
+	}
+	if string(b) != "<SC><E>OTHER</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>OTHER</E></SC>", string(b))
 	}
 }
 
@@ -1406,6 +1766,18 @@ func TestCouponFreq(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E couponFreq
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct CouponFreq): %s\n", err)
+	}
+	if string(b) != "<SC><E>OTHER</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>OTHER</E></SC>", string(b))
+	}
 }
 
 func TestCallType(t *testing.T) {
@@ -1450,6 +1822,18 @@ func TestCallType(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E callType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct CallType): %s\n", err)
+	}
+	if string(b) != "<SC><E>MATURITY</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>MATURITY</E></SC>", string(b))
 	}
 }
 
@@ -1496,6 +1880,18 @@ func TestAssetClass(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E assetClass
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct AssetClass): %s\n", err)
+	}
+	if string(b) != "<SC><E>OTHER</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>OTHER</E></SC>", string(b))
+	}
 }
 
 func TestMfType(t *testing.T) {
@@ -1540,6 +1936,18 @@ func TestMfType(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E mfType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct MfType): %s\n", err)
+	}
+	if string(b) != "<SC><E>OTHER</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>OTHER</E></SC>", string(b))
 	}
 }
 
@@ -1586,6 +1994,18 @@ func TestOptType(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E optType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct OptType): %s\n", err)
+	}
+	if string(b) != "<SC><E>CALL</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>CALL</E></SC>", string(b))
+	}
 }
 
 func TestStockType(t *testing.T) {
@@ -1630,6 +2050,18 @@ func TestStockType(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E stockType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct StockType): %s\n", err)
+	}
+	if string(b) != "<SC><E>OTHER</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>OTHER</E></SC>", string(b))
 	}
 }
 
@@ -1676,6 +2108,18 @@ func TestHolderType(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E holderType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct HolderType): %s\n", err)
+	}
+	if string(b) != "<SC><E>OTHER</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>OTHER</E></SC>", string(b))
+	}
 }
 
 func TestAcctClassification(t *testing.T) {
@@ -1720,6 +2164,18 @@ func TestAcctClassification(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E acctClassification
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct AcctClassification): %s\n", err)
+	}
+	if string(b) != "<SC><E>OTHER</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>OTHER</E></SC>", string(b))
 	}
 }
 
@@ -1766,6 +2222,18 @@ func TestSvcStatus(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
 	}
+
+	type SC struct {
+		E svcStatus
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct SvcStatus): %s\n", err)
+	}
+	if string(b) != "<SC><E>ACTIVE</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>ACTIVE</E></SC>", string(b))
+	}
 }
 
 func TestUsProductType(t *testing.T) {
@@ -1810,5 +2278,17 @@ func TestUsProductType(t *testing.T) {
 	err = xml.Unmarshal([]byte("<GARBAGE><!LALDK>"), &overwritten)
 	if err == nil {
 		t.Fatalf("Expected error unmarshalling garbage value\n")
+	}
+
+	type SC struct {
+		E usProductType
+	}
+	sc := SC{E: e}
+	b, err = xml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("Unexpected error on xml.Marshal(struct UsProductType): %s\n", err)
+	}
+	if string(b) != "<SC><E>UGMA</E></SC>" {
+		t.Fatalf("Expected '%s', got '%s'\n", "<SC><E>UGMA</E></SC>", string(b))
 	}
 }

--- a/generate_constants.py
+++ b/generate_constants.py
@@ -116,11 +116,11 @@ func (e *{enumLower}) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 	return e.FromString(value)
 }}
 
-func (e *{enumLower}) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {{
+func (e {enumLower}) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {{
 	if !e.Valid() {{
 		return nil
 	}}
-	enc.EncodeElement({enumLower}s[*e-1], start)
+	enc.EncodeElement({enumLower}s[e-1], start)
 	return nil
 }}
 
@@ -225,6 +225,18 @@ func Test{enum}(t *testing.T) {{
 	if err == nil {{
 		t.Fatalf("Expected error unmarshalling garbage value\\n")
 	}}
+
+	type SC struct {{
+		E {enumLower}
+	}}
+	sc := SC{{E: e}}
+	b, err = xml.Marshal(sc)
+	if err != nil {{
+		t.Fatalf("Unexpected error on xml.Marshal(struct {enum}): %s\\n", err)
+	}}
+	if string(b) != "<SC><E>{lastValueUpper}</E></SC>" {{
+		t.Fatalf("Expected '%s', got '%s'\\n", "<SC><E>{lastValueUpper}</E></SC>", string(b))
+	}}
 }}
 """
 
@@ -232,8 +244,10 @@ with open("constants_test.go", 'w') as f:
     f.write(test_header)
 
     for enum in enums:
+        enumLower = enum[:1].lower() + enum[1:].replace(" ", "")
         firstValueUpper = enums[enum][0][0].upper()
         lastValueUpper = enums[enum][0][-1].upper()
         f.write(test_template.format(enum=enum,
+                              enumLower=enumLower,
                               firstValueUpper=firstValueUpper,
                               lastValueUpper=lastValueUpper))

--- a/invstmt.go
+++ b/invstmt.go
@@ -911,12 +911,12 @@ func (p *PositionList) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 }
 
 // MarshalXML handles marshalling a PositionList to an XML string
-func (p *PositionList) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (p PositionList) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	invPosListElement := xml.StartElement{Name: xml.Name{Local: "INVPOSLIST"}}
 	if err := e.EncodeToken(invPosListElement); err != nil {
 		return err
 	}
-	for _, position := range *p {
+	for _, position := range p {
 		start := xml.StartElement{Name: xml.Name{Local: position.PositionType()}}
 		switch pos := position.(type) {
 		case DebtPosition:
@@ -1216,12 +1216,12 @@ func (o *OOList) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 }
 
 // MarshalXML handles marshalling an OOList to an XML string
-func (o *OOList) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (o OOList) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	ooListElement := xml.StartElement{Name: xml.Name{Local: "INVOOLIST"}}
 	if err := e.EncodeToken(ooListElement); err != nil {
 		return err
 	}
-	for _, openorder := range *o {
+	for _, openorder := range o {
 		start := xml.StartElement{Name: xml.Name{Local: openorder.OrderType()}}
 		switch oo := openorder.(type) {
 		case OOBuyDebt:

--- a/types.go
+++ b/types.go
@@ -76,7 +76,7 @@ func (a Amount) String() string {
 }
 
 // MarshalXML marshals an Amount to SGML/XML
-func (a *Amount) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (a Amount) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.EncodeElement(a.String(), start)
 }
 
@@ -188,7 +188,7 @@ func (od Date) String() string {
 }
 
 // MarshalXML marshals a Date to XML
-func (od *Date) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (od Date) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.EncodeElement(od.String(), start)
 }
 
@@ -260,8 +260,8 @@ func (ob *Boolean) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 }
 
 // MarshalXML marshals a Boolean to XML
-func (ob *Boolean) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	if *ob {
+func (ob Boolean) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if ob {
 		return e.EncodeElement("Y", start)
 	}
 	return e.EncodeElement("N", start)
@@ -358,7 +358,7 @@ func (c *CurrSymbol) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 }
 
 // MarshalXML marshals a CurrSymbol to SGML/XML
-func (c *CurrSymbol) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (c CurrSymbol) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.EncodeElement(c.String(), start)
 }
 

--- a/types_test.go
+++ b/types_test.go
@@ -91,6 +91,13 @@ func TestMarshalAmount(t *testing.T) {
 	marshalHelper(t, "-768276587425", &a)
 	a.SetFrac64(1, 12)
 	marshalHelper(t, "0.0833333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333", &a)
+
+	type AmountStruct struct {
+		A Amount
+	}
+	var as AmountStruct
+	as.A.SetFrac64(1, 8)
+	marshalHelper(t, "<A>0.125</A>", as)
 }
 
 func TestUnmarshalAmount(t *testing.T) {
@@ -185,6 +192,13 @@ func TestMarshalDate(t *testing.T) {
 	// Time zone without textual description
 	d = NewDate(2017, 3, 14, 15, 9, 26, 53*1000*1000, GMTNodesc)
 	marshalHelper(t, "20170314150926.053[0]", d)
+
+	type DateStruct struct {
+		D Date
+	}
+	d = NewDateGMT(2017, 3, 14, 15, 9, 26, 53*1000*1000)
+	ds := DateStruct{D: *d}
+	marshalHelper(t, "<D>20170314150926.053[0:GMT]</D>", ds)
 }
 
 func TestUnmarshalDate(t *testing.T) {
@@ -328,6 +342,12 @@ func TestMarshalBoolean(t *testing.T) {
 	marshalHelper(t, "Y", &b)
 	b = false
 	marshalHelper(t, "N", &b)
+
+	type BooleanStruct struct {
+		B Boolean
+	}
+	bs := BooleanStruct{B: true}
+	marshalHelper(t, "<B>Y</B>", bs)
 }
 
 func TestUnmarshalBoolean(t *testing.T) {
@@ -412,6 +432,12 @@ func TestRandomUID(t *testing.T) {
 func TestMarshalCurrSymbol(t *testing.T) {
 	c, _ := NewCurrSymbol("USD")
 	marshalHelper(t, "USD", &c)
+
+	type CurrSymbolStruct struct {
+		CS CurrSymbol
+	}
+	css := CurrSymbolStruct{CS: *c}
+	marshalHelper(t, "<CS>USD</CS>", css)
 }
 
 func TestUnmarshalCurrSymbol(t *testing.T) {


### PR DESCRIPTION
This fixes XML marshaling when these types are embedded in structs as values (vs pointers). The specific use case I have is to store the raw XML values for later processing (and unmarshaling).

I don't think this fix is complete. For example, the `InvTranList` type has the same problem, though in practice it is always embedded in a struct by pointer. I think the XML parser could check for both the marshaler interface on the type and the marshier interface on the pointer to the type when iterating through structs.